### PR TITLE
Fix the description of coins distribution.

### DIFF
--- a/components/About/Phase.tsx
+++ b/components/About/Phase.tsx
@@ -57,7 +57,7 @@ export const Phase = ({
         </h4>
         <p className={clsx('my-2', 'text-left', 'w-full', 'text-lg')}>
           {capitalDigit(pools.length)} prize{' '}
-          {pools.length === 1 ? 'pool' : 'pools'} totalling{' '}
+          {pools.length === 1 ? 'pool' : 'pools'} totalling up to{' '}
           {cumulativePoolSize(pools)} coins
         </p>
         <p className={clsx('text-left', 'w-full')}>{summary}</p>


### PR DESCRIPTION
After adding "Prize pool 3" we have inconsistency in the description. The current text is "Two prize pools totalling 525 000 coins" (what means some exact value). But according to the fact that "Prize pool 3 coins (spans all phases)" it would be better to change the text to "Two prize pools totalling up to 525 000 coins".

## Summary

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
